### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "drupal/token_filter",
+    "description": "This is a very simple module to make global token values available as an input filter.",
+    "type": "drupal-module",
+    "license": "GPL-2.0+"
+}


### PR DESCRIPTION
Adding a composer.json file allows us to text/use this module before it hits d.o.
The file can stay in there on d.o. it wont break anything. :)
